### PR TITLE
fix: org syntax highlighting outside of codeblocks and more settings

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,9 +91,12 @@ type StatesConfig struct {
 
 // UIConfig holds UI-related configurations
 type UIConfig struct {
-	HelpTextWidth      int `toml:"help_text_width"`
-	MinTerminalWidth   int `toml:"min_terminal_width"`
-	AgendaDays         int `toml:"agenda_days"`
+	HelpTextWidth         int    `toml:"help_text_width"`
+	MinTerminalWidth      int    `toml:"min_terminal_width"`
+	AgendaDays            int    `toml:"agenda_days"`
+	OrgSyntaxHighlighting bool   `toml:"org_syntax_highlighting"`
+	ShowIndentationGuides bool   `toml:"show_indentation_guides"`
+	IndentationGuideColor string `toml:"indentation_guide_color"`
 }
 
 // DefaultConfig returns the default configuration
@@ -161,9 +164,12 @@ func DefaultConfig() *Config {
 			DefaultNewTaskState: "TODO",
 		},
 		UI: UIConfig{
-			HelpTextWidth:    22,
-			MinTerminalWidth: 40,
-			AgendaDays:       7,
+			HelpTextWidth:         22,
+			MinTerminalWidth:      40,
+			AgendaDays:            7,
+			OrgSyntaxHighlighting: true,
+			ShowIndentationGuides: true,
+			IndentationGuideColor: "245",
 		},
 	}
 }
@@ -371,10 +377,11 @@ func (c *Config) fillDefaults() {
 	// Fill states if empty
 	if len(c.States.States) == 0 {
 		c.States.States = defaults.States.States
-	}
-	if c.States.DefaultNewTaskState == "" {
+		// Also set the default new task state since the entire states section is missing
 		c.States.DefaultNewTaskState = defaults.States.DefaultNewTaskState
 	}
+	// Note: We don't fill DefaultNewTaskState if States.States is non-empty because
+	// an empty string is a valid intentional value meaning "no default state".
 
 	// Fill UI if zero values
 	if c.UI.HelpTextWidth == 0 {
@@ -385,6 +392,9 @@ func (c *Config) fillDefaults() {
 	}
 	if c.UI.AgendaDays == 0 {
 		c.UI.AgendaDays = defaults.UI.AgendaDays
+	}
+	if c.UI.IndentationGuideColor == "" {
+		c.UI.IndentationGuideColor = defaults.UI.IndentationGuideColor
 	}
 }
 

--- a/internal/model/item.go
+++ b/internal/model/item.go
@@ -21,6 +21,7 @@ type Item struct {
 	Tags         []string     // Tags for this item (e.g., :work:urgent:)
 	Scheduled    *time.Time
 	Deadline     *time.Time
+	Closed       *time.Time   // Closed timestamp (when task was marked as done)
 	Effort       string       // Effort estimate (e.g., "8h", "2d")
 	Notes        []string     // Notes/content under the heading
 	Children     []*Item      // Sub-items

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -14,15 +14,16 @@ import (
 
 // Parser patterns
 var (
-	scheduledPattern    = regexp.MustCompile(`SCHEDULED:\s*<([^>]+)>`)
-	deadlinePattern     = regexp.MustCompile(`DEADLINE:\s*<([^>]+)>`)
-	clockPattern        = regexp.MustCompile(`CLOCK:\s*\[([^\]]+)\](?:--\[([^\]]+)\])?`)
-	effortPattern       = regexp.MustCompile(`^\s*:EFFORT:\s*(.+)$`)
-	logbookDrawerStart  = regexp.MustCompile(`^\s*:LOGBOOK:\s*$`)
+	scheduledPattern      = regexp.MustCompile(`SCHEDULED:\s*<([^>]+)>`)
+	deadlinePattern       = regexp.MustCompile(`DEADLINE:\s*<([^>]+)>`)
+	closedPattern         = regexp.MustCompile(`CLOSED:\s*\[([^\]]+)\]`)
+	clockPattern          = regexp.MustCompile(`CLOCK:\s*\[([^\]]+)\](?:--\[([^\]]+)\])?`)
+	effortPattern         = regexp.MustCompile(`^\s*:EFFORT:\s*(.+)$`)
+	logbookDrawerStart    = regexp.MustCompile(`^\s*:LOGBOOK:\s*$`)
 	propertiesDrawerStart = regexp.MustCompile(`^\s*:PROPERTIES:\s*$`)
-	drawerEnd           = regexp.MustCompile(`^\s*:END:\s*$`)
-	codeBlockStart      = regexp.MustCompile(`^\s*#\+BEGIN_SRC`)
-	codeBlockEnd        = regexp.MustCompile(`^\s*#\+END_SRC`)
+	drawerEnd             = regexp.MustCompile(`^\s*:END:\s*$`)
+	codeBlockStart        = regexp.MustCompile(`^\s*#\+BEGIN_SRC`)
+	codeBlockEnd          = regexp.MustCompile(`^\s*#\+END_SRC`)
 )
 
 // buildHeadingPattern creates a regex pattern that matches configured states
@@ -184,6 +185,13 @@ func ParseOrgFile(path string, cfg *config.Config) (*model.OrgFile, error) {
 			if matches := deadlinePattern.FindStringSubmatch(line); matches != nil {
 				if t, err := parseOrgDate(matches[1]); err == nil {
 					currentItem.Deadline = &t
+				}
+			}
+
+			// Check for CLOSED
+			if matches := closedPattern.FindStringSubmatch(line); matches != nil {
+				if t, err := parseClockTimestamp(matches[1]); err == nil {
+					currentItem.Closed = &t
 				}
 			}
 

--- a/internal/parser/writer.go
+++ b/internal/parser/writer.go
@@ -128,6 +128,7 @@ func writeItem(writer *bufio.Writer, item *model.Item) error {
 	// Write scheduling info if not already in notes
 	hasScheduled := false
 	hasDeadline := false
+	hasClosed := false
 	hasLogbook := false
 	hasProperties := false
 	for _, note := range item.Notes {
@@ -137,11 +138,21 @@ func writeItem(writer *bufio.Writer, item *model.Item) error {
 		if strings.Contains(note, "DEADLINE:") {
 			hasDeadline = true
 		}
+		if strings.Contains(note, "CLOSED:") {
+			hasClosed = true
+		}
 		if strings.Contains(note, ":LOGBOOK:") {
 			hasLogbook = true
 		}
 		if strings.Contains(note, ":PROPERTIES:") {
 			hasProperties = true
+		}
+	}
+
+	if item.Closed != nil && !hasClosed {
+		closedLine := fmt.Sprintf("CLOSED: [%s]\n", formatClockTimestamp(*item.Closed))
+		if _, err := writer.WriteString(closedLine); err != nil {
+			return err
 		}
 	}
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -112,7 +112,7 @@ func (m *uiModel) updateScrollOffset(availableHeight int) {
 			noteIndent := indent + "  "
 			filteredNotes := filterLogbookDrawer(item.Notes)
 			wrappedNotes := wrapNoteLines(filteredNotes, m.width, noteIndent)
-			highlightedNotes := renderNotesWithHighlighting(wrappedNotes)
+			highlightedNotes := m.renderNotesWithHighlighting(wrappedNotes)
 			lineCount += len(highlightedNotes)
 		}
 		itemLineCount[i] = lineCount


### PR DESCRIPTION
## Description

This adds a "General" settings tab with options for indentation and org syntax highlighting.

Slight bug in this:
Huge org files might get slowed down by the highlighting, hence the setting being togglable

## Important note

The first commit should be prefixed with one of the following depending on the severity of the changes:

- `chore:` - non-code changes, such as typos in readme or pipeline changes.
- `fix:` - for a small change like a bugfix or other minor things.
- `feat:` - for a new feature.
- `major:` - for a large refactor or breaking changes.